### PR TITLE
Enhance CLI with interactive updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ python timecounter.py path/to/log.txt
 The tool prints the total hours since the last `ОПЛАЧЕНО` entry and, if the
 log contains a subsequent `СЧЕТ ВЫСТАВЛЕН` line, also reports the hours that
 were already invoiced but not yet paid.
+
+After displaying the calculated time, the program interactively offers to:
+
+* mark the invoiced period as paid;
+* mark the last unpaid period as invoiced;
+* append additional log entries.
+
+Any confirmed changes are immediately written back to the log file.


### PR DESCRIPTION
## Summary
- allow marking invoiced period as paid or marking last period as invoiced
- keep original CRLF formatting in log files when modifying them
- add ability to append new log lines interactively
- document new interactive features in README

## Testing
- `python -m py_compile timecounter.py`
- `python timecounter.py DeepAssistTime.txt` *(fails: EOFError when no interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_68489d4048248323880c08c258d52489