### PR TITLE
Improve timer editing UI

### DIFF
--- a/pomodoro.py
+++ b/pomodoro.py
@@ -1,10 +1,9 @@
 # Pomodoro timer application using Tkinter
 
 import tkinter as tk
-from tkinter import ttk, simpledialog, messagebox
+from tkinter import ttk, messagebox
 import json
 import os
-import time
 
 CONFIG_DIR = "timers"
 
@@ -91,6 +90,211 @@ class TimerManager:
             os.rename(old_path, new_path)
         self.save_timer(timer)
 
+
+class TimeEntry(ttk.Entry):
+    """Entry widget for time in HH:MM:SS format with digit based editing."""
+
+    def __init__(self, master, seconds=0, **kwargs):
+        self.var = tk.StringVar()
+        super().__init__(master, textvariable=self.var, **kwargs)
+        self.set_seconds(seconds)
+        self.bind("<KeyRelease>", self._on_key)
+
+    def _on_key(self, event):
+        digits = "".join(ch for ch in self.var.get() if ch.isdigit())
+        if not digits:
+            self.var.set("00:00:00")
+            return
+        sec = int(digits[-2:]) if len(digits) >= 2 else int(digits)
+        sec = min(sec, 59)
+        minute_digits = digits[-4:-2] if len(digits) > 2 else ""
+        minutes = int(minute_digits) if minute_digits else 0
+        minutes = min(minutes, 59)
+        hour_digits = digits[:-4] if len(digits) > 4 else ""
+        hours = int(hour_digits) if hour_digits else 0
+        self.var.set(f"{hours:02d}:{minutes:02d}:{sec:02d}")
+        self.icursor(tk.END)
+
+    def get_seconds(self):
+        try:
+            h, m, s = [int(x) for x in self.var.get().split(":")]
+        except ValueError:
+            return 0
+        m = min(m, 59)
+        s = min(s, 59)
+        return h * 3600 + m * 60 + s
+
+    def set_seconds(self, sec):
+        h, rem = divmod(int(sec), 3600)
+        m, s = divmod(rem, 60)
+        self.var.set(f"{h:02d}:{m:02d}:{s:02d}")
+
+
+class ActivityDialog(tk.Toplevel):
+    """Dialog for editing or creating a single activity."""
+
+    def __init__(self, parent, activity=None):
+        super().__init__(parent)
+        self.title("Activity")
+        self.resizable(False, False)
+        self.result = None
+
+        ttk.Label(self, text="Name").grid(row=0, column=0, sticky="w")
+        self.entry_name = ttk.Entry(self)
+        self.entry_name.grid(row=1, column=0, padx=5, sticky="we")
+
+        ttk.Label(self, text="Duration").grid(row=2, column=0, sticky="w")
+        self.time_entry = TimeEntry(self)
+        self.time_entry.grid(row=3, column=0, padx=5, sticky="we")
+
+        btn = ttk.Frame(self)
+        btn.grid(row=4, column=0, pady=5, sticky="e")
+        ttk.Button(btn, text="OK", command=self._ok).grid(row=0, column=0, padx=2)
+        ttk.Button(btn, text="Cancel", command=self.destroy).grid(row=0, column=1, padx=2)
+
+        if activity:
+            self.entry_name.insert(0, activity.name)
+            self.time_entry.set_seconds(activity.duration)
+
+        self.columnconfigure(0, weight=1)
+
+    def _ok(self):
+        name = self.entry_name.get().strip()
+        if not name:
+            return
+        duration = self.time_entry.get_seconds()
+        if duration <= 0:
+            return
+        self.result = (name, duration)
+        self.destroy()
+
+
+class TimerEditorFrame(ttk.Frame):
+    """Editing UI placed inside the main application window."""
+
+    def __init__(self, parent, manager, close_callback):
+        super().__init__(parent)
+        self.manager = manager
+        self.close_callback = close_callback
+        self.timer = None
+        self._build_widgets()
+        self.grid_columnconfigure(0, weight=1)
+
+    def _build_widgets(self):
+        ttk.Label(self, text="Name").grid(row=0, column=0, sticky="w")
+        self.entry_name = ttk.Entry(self)
+        self.entry_name.grid(row=1, column=0, sticky="we", pady=(0, 5))
+
+        ttk.Label(self, text="Description").grid(row=2, column=0, sticky="w")
+        self.text_desc = tk.Text(self, height=3, width=30)
+        self.text_desc.grid(row=3, column=0, sticky="we", pady=(0, 5))
+
+        ttk.Label(self, text="Sets").grid(row=4, column=0, sticky="w")
+        self.spin_sets = ttk.Spinbox(self, from_=1, to=20, width=5)
+        self.spin_sets.grid(row=5, column=0, sticky="w", pady=(0, 5))
+
+        ttk.Label(self, text="Rest between activities").grid(row=6, column=0, sticky="w")
+        self.time_rest_act = TimeEntry(self)
+        self.time_rest_act.grid(row=7, column=0, sticky="w", pady=(0, 5))
+
+        ttk.Label(self, text="Rest between sets").grid(row=8, column=0, sticky="w")
+        self.time_rest_set = TimeEntry(self)
+        self.time_rest_set.grid(row=9, column=0, sticky="w", pady=(0, 5))
+
+        ttk.Label(self, text="Activities").grid(row=10, column=0, sticky="w")
+        self.listbox = tk.Listbox(self, height=8)
+        self.listbox.grid(row=11, column=0, sticky="we")
+        self.listbox.bind('<Button-1>', self.set_drag_start)
+        self.listbox.bind('<B1-Motion>', self.drag_motion)
+        self.drag_index = None
+
+        act_btns = ttk.Frame(self)
+        act_btns.grid(row=12, column=0, sticky="w")
+        ttk.Button(act_btns, text="Add", command=self.add_activity).grid(row=0, column=0, padx=2)
+        ttk.Button(act_btns, text="Edit", command=self.edit_activity).grid(row=0, column=1, padx=2)
+        ttk.Button(act_btns, text="Delete", command=self.delete_activity).grid(row=0, column=2, padx=2)
+
+        btn_frame = ttk.Frame(self)
+        btn_frame.grid(row=13, column=0, sticky="e", pady=5)
+        ttk.Button(btn_frame, text="Save", command=self.save).grid(row=0, column=0, padx=2)
+        ttk.Button(btn_frame, text="Cancel", command=self.cancel).grid(row=0, column=1, padx=2)
+
+    def edit_timer(self, timer=None):
+        self.timer = timer or TimerConfig("New Timer")
+        self.entry_name.delete(0, tk.END)
+        self.entry_name.insert(0, self.timer.name)
+        self.text_desc.delete("1.0", tk.END)
+        self.text_desc.insert("1.0", self.timer.description)
+        self.spin_sets.delete(0, tk.END)
+        self.spin_sets.insert(0, str(self.timer.sets))
+        self.time_rest_act.set_seconds(self.timer.rest_activity)
+        self.time_rest_set.set_seconds(self.timer.rest_set)
+        self.refresh_listbox()
+        self.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+    def cancel(self):
+        self.pack_forget()
+        if self.close_callback:
+            self.close_callback()
+
+    def set_drag_start(self, event):
+        self.drag_index = self.listbox.nearest(event.y)
+
+    def drag_motion(self, event):
+        new_index = self.listbox.nearest(event.y)
+        if new_index != self.drag_index:
+            self.timer.activities.insert(new_index, self.timer.activities.pop(self.drag_index))
+            self.refresh_listbox()
+            self.drag_index = new_index
+
+    def refresh_listbox(self):
+        self.listbox.delete(0, tk.END)
+        for act in self.timer.activities:
+            self.listbox.insert(tk.END, f"{act.name} ({self.format_time(act.duration)})")
+
+    def format_time(self, sec):
+        h, rem = divmod(sec, 3600)
+        m, s = divmod(rem, 60)
+        return f"{h:02d}:{m:02d}:{s:02d}"
+
+    def add_activity(self):
+        dlg = ActivityDialog(self)
+        self.wait_window(dlg)
+        if dlg.result:
+            name, duration = dlg.result
+            self.timer.activities.append(Activity(name, duration))
+            self.refresh_listbox()
+
+    def edit_activity(self):
+        idxs = self.listbox.curselection()
+        if not idxs:
+            return
+        idx = idxs[0]
+        act = self.timer.activities[idx]
+        dlg = ActivityDialog(self, act)
+        self.wait_window(dlg)
+        if dlg.result:
+            name, duration = dlg.result
+            act.name = name
+            act.duration = duration
+            self.refresh_listbox()
+
+    def delete_activity(self):
+        idxs = self.listbox.curselection()
+        if not idxs:
+            return
+        del self.timer.activities[idxs[0]]
+        self.refresh_listbox()
+
+    def save(self):
+        self.timer.name = self.entry_name.get().strip()
+        self.timer.description = self.text_desc.get("1.0", "end").strip()
+        self.timer.sets = int(self.spin_sets.get())
+        self.timer.rest_activity = self.time_rest_act.get_seconds()
+        self.timer.rest_set = self.time_rest_set.get_seconds()
+        self.manager.save_timer(self.timer)
+        self.cancel()
+
 class TimerRunner:
     def __init__(self, parent, timer: TimerConfig):
         self.parent = parent
@@ -126,8 +330,9 @@ class TimerRunner:
         self.update_display()
 
     def format_time(self, seconds):
-        m, s = divmod(int(seconds), 60)
-        return f"{m:02d}:{s:02d}"
+        h, rem = divmod(int(seconds), 3600)
+        m, s = divmod(rem, 60)
+        return f"{h:02d}:{m:02d}:{s:02d}"
 
     def update_display(self):
         if self.current_index < len(self.timer.activities):
@@ -206,130 +411,19 @@ class TimerRunner:
         else:
             self.advance()
 
-class TimerEditor:
-    def __init__(self, parent, manager: TimerManager, timer: TimerConfig = None):
-        self.parent = parent
-        self.manager = manager
-        self.timer = timer or TimerConfig("New Timer")
-        self.window = tk.Toplevel(parent)
-        self.window.title("Timer Editor")
-
-        ttk.Label(self.window, text="Name:").grid(row=0, column=0, sticky="e")
-        self.entry_name = ttk.Entry(self.window)
-        self.entry_name.grid(row=0, column=1, sticky="we")
-        self.entry_name.insert(0, self.timer.name)
-
-        ttk.Label(self.window, text="Description:").grid(row=1, column=0, sticky="ne")
-        self.text_desc = tk.Text(self.window, height=3, width=30)
-        self.text_desc.grid(row=1, column=1, sticky="we")
-        self.text_desc.insert("1.0", self.timer.description)
-
-        ttk.Label(self.window, text="Sets:").grid(row=2, column=0, sticky="e")
-        self.spin_sets = ttk.Spinbox(self.window, from_=1, to=20, width=5)
-        self.spin_sets.grid(row=2, column=1, sticky="w")
-        self.spin_sets.delete(0, "end")
-        self.spin_sets.insert(0, str(self.timer.sets))
-
-        ttk.Label(self.window, text="Rest between activities (sec):").grid(row=3, column=0, sticky="e")
-        self.spin_rest_act = ttk.Spinbox(self.window, from_=0, to=3600, width=5)
-        self.spin_rest_act.grid(row=3, column=1, sticky="w")
-        self.spin_rest_act.delete(0, "end")
-        self.spin_rest_act.insert(0, str(self.timer.rest_activity))
-
-        ttk.Label(self.window, text="Rest between sets (sec):").grid(row=4, column=0, sticky="e")
-        self.spin_rest_set = ttk.Spinbox(self.window, from_=0, to=7200, width=5)
-        self.spin_rest_set.grid(row=4, column=1, sticky="w")
-        self.spin_rest_set.delete(0, "end")
-        self.spin_rest_set.insert(0, str(self.timer.rest_set))
-
-        ttk.Label(self.window, text="Activities:").grid(row=5, column=0, sticky="ne")
-        self.listbox = tk.Listbox(self.window, height=8)
-        self.listbox.grid(row=5, column=1, sticky="we")
-        self.listbox.bind('<Button-1>', self.set_drag_start)
-        self.listbox.bind('<B1-Motion>', self.drag_motion)
-        self.drag_index = None
-        self.refresh_listbox()
-
-        act_btns = ttk.Frame(self.window)
-        act_btns.grid(row=6, column=1, sticky="w")
-        ttk.Button(act_btns, text="Add", command=self.add_activity).grid(row=0, column=0, padx=2)
-        ttk.Button(act_btns, text="Edit", command=self.edit_activity).grid(row=0, column=1, padx=2)
-        ttk.Button(act_btns, text="Delete", command=self.delete_activity).grid(row=0, column=2, padx=2)
-
-        btn_frame = ttk.Frame(self.window)
-        btn_frame.grid(row=7, column=1, sticky="e")
-        ttk.Button(btn_frame, text="Save", command=self.save).grid(row=0, column=0, padx=2)
-        ttk.Button(btn_frame, text="Cancel", command=self.window.destroy).grid(row=0, column=1, padx=2)
-
-        self.window.columnconfigure(1, weight=1)
-
-    def set_drag_start(self, event):
-        self.drag_index = self.listbox.nearest(event.y)
-
-    def drag_motion(self, event):
-        new_index = self.listbox.nearest(event.y)
-        if new_index != self.drag_index:
-            self.timer.activities.insert(new_index, self.timer.activities.pop(self.drag_index))
-            self.refresh_listbox()
-            self.drag_index = new_index
-
-    def refresh_listbox(self):
-        self.listbox.delete(0, tk.END)
-        for act in self.timer.activities:
-            self.listbox.insert(tk.END, f"{act.name} ({self.format_time(act.duration)})")
-
-    def format_time(self, sec):
-        m, s = divmod(sec, 60)
-        return f"{m:02d}:{s:02d}"
-
-    def add_activity(self):
-        name = simpledialog.askstring("Activity", "Name:", parent=self.window)
-        if not name:
-            return
-        duration = simpledialog.askinteger("Activity", "Duration (seconds):", parent=self.window, minvalue=1)
-        if duration:
-            self.timer.activities.append(Activity(name, duration))
-            self.refresh_listbox()
-
-    def edit_activity(self):
-        idx = self.listbox.curselection()
-        if not idx:
-            return
-        idx = idx[0]
-        act = self.timer.activities[idx]
-        name = simpledialog.askstring("Activity", "Name:", initialvalue=act.name, parent=self.window)
-        if not name:
-            return
-        duration = simpledialog.askinteger("Activity", "Duration (seconds):", initialvalue=act.duration, parent=self.window, minvalue=1)
-        if duration:
-            act.name = name
-            act.duration = duration
-            self.refresh_listbox()
-
-    def delete_activity(self):
-        idx = self.listbox.curselection()
-        if not idx:
-            return
-        idx = idx[0]
-        del self.timer.activities[idx]
-        self.refresh_listbox()
-
-    def save(self):
-        self.timer.name = self.entry_name.get()
-        self.timer.description = self.text_desc.get("1.0", "end").strip()
-        self.timer.sets = int(self.spin_sets.get())
-        self.timer.rest_activity = int(self.spin_rest_act.get())
-        self.timer.rest_set = int(self.spin_rest_set.get())
-        self.manager.save_timer(self.timer)
-        self.window.destroy()
 
 class MainApp(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title("Pomodoro Timer")
-        self.geometry("500x400")
+        self.geometry("700x400")
         self.manager = TimerManager()
+        self.editor = TimerEditorFrame(self, self.manager, self.on_editor_closed)
         self.create_widgets()
+
+    def on_editor_closed(self):
+        self.manager.load_timers()
+        self.refresh_timer_list()
 
     def create_widgets(self):
         left = ttk.Frame(self)
@@ -347,6 +441,8 @@ class MainApp(tk.Tk):
         ttk.Button(btn_frame, text="Delete", command=self.delete_timer).grid(row=0, column=2, padx=2)
         ttk.Button(btn_frame, text="Run", command=self.run_timer).grid(row=0, column=3, padx=2)
 
+        self.editor.pack_forget()
+
     def refresh_timer_list(self):
         self.timer_list.delete(0, tk.END)
         for name in sorted(self.manager.timers.keys()):
@@ -359,20 +455,14 @@ class MainApp(tk.Tk):
         return self.timer_list.get(sel[0])
 
     def new_timer(self):
-        TimerEditor(self, self.manager)
-        self.wait_window(self.winfo_children()[-1])
-        self.manager.load_timers()
-        self.refresh_timer_list()
+        self.editor.edit_timer()
 
     def edit_timer(self):
         name = self.get_selected_name()
         if not name:
             return
         timer = self.manager.timers[name]
-        TimerEditor(self, self.manager, timer)
-        self.wait_window(self.winfo_children()[-1])
-        self.manager.load_timers()
-        self.refresh_timer_list()
+        self.editor.edit_timer(timer)
 
     def delete_timer(self):
         name = self.get_selected_name()


### PR DESCRIPTION
## Summary
- move timer editor into the main window using new `TimerEditorFrame`
- create `TimeEntry` widget handling HH:MM:SS input
- add `ActivityDialog` for editing activity name and duration in one window
- adjust timer display to show hours
- remove unused separate editor class

## Testing
- `python -m py_compile pomodoro.py`

------
https://chatgpt.com/codex/tasks/task_e_68585e30bf288323a2f854065e5c0230