### PR TITLE
Improve timer editor layout and add popup switch

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ class MainApp(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title("Pomodoro Timer")
-        self.geometry("700x400")
+        self.geometry("700x550")
         self.manager = TimerManager()
         self.editor = TimerEditorFrame(self, self.manager, self.on_editor_closed)
         self.create_widgets()

--- a/timer_editor.py
+++ b/timer_editor.py
@@ -15,31 +15,32 @@ class TimerEditorFrame(ttk.Frame):
         self.timer = None
         self._build_widgets()
         self.grid_columnconfigure(0, weight=1)
+        self.grid_columnconfigure(1, weight=1)
 
     def _build_widgets(self):
-        ttk.Label(self, text="Name").grid(row=0, column=0, sticky="w")
+        ttk.Label(self, text="Name").grid(row=0, column=0, columnspan=2, sticky="w")
         self.entry_name = ttk.Entry(self)
-        self.entry_name.grid(row=1, column=0, sticky="we", pady=(0, 5))
+        self.entry_name.grid(row=1, column=0, columnspan=2, sticky="we", pady=(0, 5))
 
-        ttk.Label(self, text="Description").grid(row=2, column=0, sticky="w")
+        ttk.Label(self, text="Description").grid(row=2, column=0, columnspan=2, sticky="w")
         self.text_desc = tk.Text(self, height=3, width=30)
-        self.text_desc.grid(row=3, column=0, sticky="we", pady=(0, 5))
+        self.text_desc.grid(row=3, column=0, columnspan=2, sticky="we", pady=(0, 5))
 
-        ttk.Label(self, text="Sets").grid(row=4, column=0, sticky="w")
+        ttk.Label(self, text="Sets").grid(row=4, column=0, columnspan=2, sticky="w")
         self.spin_sets = ttk.Spinbox(self, from_=1, to=20, width=5)
-        self.spin_sets.grid(row=5, column=0, sticky="w", pady=(0, 5))
+        self.spin_sets.grid(row=5, column=0, columnspan=2, sticky="w", pady=(0, 5))
 
-        ttk.Label(self, text="Rest between activities").grid(row=6, column=0, sticky="w")
+        ttk.Label(self, text="Rest between activities").grid(row=6, column=0, columnspan=2, sticky="w")
         self.time_rest_act = TimeEntry(self)
-        self.time_rest_act.grid(row=7, column=0, sticky="w", pady=(0, 5))
+        self.time_rest_act.grid(row=7, column=0, columnspan=2, sticky="w", pady=(0, 5))
 
-        ttk.Label(self, text="Rest between sets").grid(row=8, column=0, sticky="w")
+        ttk.Label(self, text="Rest between sets").grid(row=8, column=0, columnspan=2, sticky="w")
         self.time_rest_set = TimeEntry(self)
-        self.time_rest_set.grid(row=9, column=0, sticky="w", pady=(0, 5))
+        self.time_rest_set.grid(row=9, column=0, columnspan=2, sticky="w", pady=(0, 5))
 
-        ttk.Label(self, text="Activities").grid(row=10, column=0, sticky="w")
+        ttk.Label(self, text="Activities").grid(row=10, column=0, columnspan=2, sticky="w")
         self.listbox = tk.Listbox(self, height=8)
-        self.listbox.grid(row=11, column=0, sticky="we")
+        self.listbox.grid(row=11, column=0, columnspan=2, sticky="we")
         self.listbox.bind('<Button-1>', self.set_drag_start)
         self.listbox.bind('<B1-Motion>', self.drag_motion)
         self.drag_index = None
@@ -51,7 +52,7 @@ class TimerEditorFrame(ttk.Frame):
         ttk.Button(act_btns, text="Delete", command=self.delete_activity).grid(row=0, column=2, padx=2)
 
         btn_frame = ttk.Frame(self)
-        btn_frame.grid(row=13, column=0, sticky="e", pady=5)
+        btn_frame.grid(row=12, column=1, sticky="e", pady=5)
         ttk.Button(btn_frame, text="Save", command=self.save).grid(row=0, column=0, padx=2)
         ttk.Button(btn_frame, text="Cancel", command=self.cancel).grid(row=0, column=1, padx=2)
 

--- a/timer_runner.py
+++ b/timer_runner.py
@@ -39,6 +39,17 @@ class TimerRunner:
 
         self.update_display()
 
+    def _popup(self):
+        """Show the window in the center of the screen above others."""
+        self.window.deiconify()
+        self.window.lift()
+        self.window.attributes('-topmost', True)
+        self.window.update_idletasks()
+        x = (self.window.winfo_screenwidth() - self.window.winfo_width()) // 2
+        y = (self.window.winfo_screenheight() - self.window.winfo_height()) // 2
+        self.window.geometry(f"+{x}+{y}")
+        self.window.after(1000, lambda: self.window.attributes('-topmost', False))
+
     def format_time(self, seconds):
         h, rem = divmod(int(seconds), 3600)
         m, s = divmod(rem, 60)
@@ -89,7 +100,7 @@ class TimerRunner:
             self.window.after_cancel(self.timer_id)
         self.advance()
 
-    def advance(self):
+    def advance(self, auto=False):
         if self.state == "activity":
             if self.current_index < len(self.timer.activities) - 1:
                 self.state = "rest_activity"
@@ -98,10 +109,14 @@ class TimerRunner:
                 self.state = "rest_set"
                 self.remaining = self.timer.rest_set
             self.update_display()
+            if auto and self.window.state() != 'normal':
+                self._popup()
             self.tick()
         elif self.state == "rest_activity":
             self.current_index += 1
             self.start_current_activity()
+            if auto and self.window.state() != 'normal':
+                self._popup()
             if self.running:
                 self.tick()
         else:  # rest_set
@@ -112,6 +127,8 @@ class TimerRunner:
                 return
             self.current_index = 0
             self.start_current_activity()
+            if auto and self.window.state() != 'normal':
+                self._popup()
             if self.running:
                 self.tick()
 
@@ -123,4 +140,4 @@ class TimerRunner:
             self.remaining -= 1
             self.timer_id = self.window.after(1000, self.tick)
         else:
-            self.advance()
+            self.advance(auto=True)


### PR DESCRIPTION
## Summary
- enlarge default window to `700x550` so all controls are visible
- align Save/Cancel buttons beside Add/Edit/Delete in timer editor
- pop timer window to the front and centre when a step auto-advances

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685871c813908323bc5b1a5dedb3be2f