### PR TITLE
Fix pipeline modules and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# extracts noise from YT videos
+# WorkTimeTracker
+
+This project downloads noise videos from YouTube, converts them into short seamless loops and plays them continuously. It can be useful for creating background ambience during work or study sessions.
+
+## Requirements
+
+Install dependencies from `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+`ffmpeg` is also required and should be available in your `PATH`.
+
+## Usage
+
+Adjust `pipeline_config.yaml` to set the list of YouTube URLs and output file names. Then run:
+
+```bash
+python main.py
+```
+
+The script will download audio, prepare a loop for each target and start playback.
+
+Press `Ctrl+C` to stop playback.

--- a/download_audio.py
+++ b/download_audio.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from yt_dlp import YoutubeDL
+
+
+def download(url: str, dst: Path) -> None:
+    """Download audio from YouTube into the given file."""
+    dst = Path(dst)
+    opts = {
+        "format": "bestaudio/best",
+        "outtmpl": str(dst),
+        "quiet": True,
+        "noplaylist": True,
+    }
+    with YoutubeDL(opts) as ydl:
+        ydl.download([url])


### PR DESCRIPTION
## Summary
- document the project usage
- provide a simple `download` helper using yt-dlp
- add `play_loop` implementation and clean up unused import

## Testing
- `python3 -m py_compile main.py play_loop.py prepare_loop.py download_audio.py`

------
https://chatgpt.com/codex/tasks/task_e_6859bae9b71883238a3d95b0d5832c34