### PR TITLE
Fix period parsing and adjust separators

### DIFF
--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -1,0 +1,24 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from worktime.counter import TimeCounter
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+LOG_PATH = os.path.join(ROOT, 'FlowsTime.txt')
+
+def test_parse_periods_splits_on_status_lines():
+    tc = TimeCounter(LOG_PATH)
+    periods = tc.parse_periods()
+    # Ensure separate periods are produced for each payment line
+    assert len(periods) == 4
+    assert periods[0]['status'].endswith('ОПЛАЧЕНО')
+    assert periods[1]['status'].endswith('ОПЛАЧЕНО')
+    assert periods[2]['status'].endswith('ОПЛАЧЕНО')
+
+
+def test_no_separators_outside_work_blocks():
+    tc = TimeCounter(LOG_PATH)
+    lines = tc.intervals_with_statuses()
+    # dash should appear only between first two intervals of the first day
+    assert lines[1] == '------------'
+    assert lines[3] != '------------'  # no dash after the last interval of the day


### PR DESCRIPTION
## Summary
- fix parse_periods so payment lines that start with dates are handled as status lines
- show rest separators only between work blocks of the same day
- add regression tests for parsing and separators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859cf4830a0832397cea816b63c8187