### PR TITLE
Improve timer UX

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,30 +22,32 @@ class MainApp(tk.Tk):
         left = ttk.Frame(self)
         left.pack(side=tk.LEFT, fill=tk.Y, padx=5, pady=5)
 
-        ttk.Label(left, text="Timers").pack()
-        self.timer_list = tk.Listbox(left, height=20)
+        ttk.Label(left, text="Timers").pack(anchor="w")
+        columns = ("edit", "run", "delete")
+        self.timer_list = ttk.Treeview(left, columns=columns, show="tree")
+        self.timer_list.column("#0", stretch=True)
+        for col in columns:
+            self.timer_list.column(col, width=30, anchor="center", stretch=False)
         self.timer_list.pack(fill=tk.BOTH, expand=True)
+        self.timer_list.bind("<Double-1>", self.on_double_click)
+        self.timer_list.bind("<Button-1>", self.on_click)
+        self.timer_list.bind("<Delete>", self.on_delete_key)
         self.refresh_timer_list()
 
-        btn_frame = ttk.Frame(left)
-        btn_frame.pack(pady=5)
-        ttk.Button(btn_frame, text="New", command=self.new_timer).grid(row=0, column=0, padx=2)
-        ttk.Button(btn_frame, text="Edit", command=self.edit_timer).grid(row=0, column=1, padx=2)
-        ttk.Button(btn_frame, text="Delete", command=self.delete_timer).grid(row=0, column=2, padx=2)
-        ttk.Button(btn_frame, text="Run", command=self.run_timer).grid(row=0, column=3, padx=2)
+        ttk.Button(left, text="+ New Timer", command=self.new_timer).pack(pady=5, fill=tk.X)
 
         self.editor.pack_forget()
 
     def refresh_timer_list(self):
-        self.timer_list.delete(0, tk.END)
+        self.timer_list.delete(*self.timer_list.get_children())
         for name in sorted(self.manager.timers.keys()):
-            self.timer_list.insert(tk.END, name)
+            self.timer_list.insert("", tk.END, iid=name, text=name, values=("✏", "▶", "🗑"))
 
     def get_selected_name(self):
-        sel = self.timer_list.curselection()
+        sel = self.timer_list.selection()
         if not sel:
             return None
-        return self.timer_list.get(sel[0])
+        return sel[0]
 
     def new_timer(self):
         self.editor.edit_timer()
@@ -61,7 +63,7 @@ class MainApp(tk.Tk):
         name = self.get_selected_name()
         if not name:
             return
-        if messagebox.askyesno("Delete", f"Delete timer '{name}'?"):
+        if messagebox.askokcancel("Delete", f"Вы действительно хотите удалить таймер '{name}'?"):
             self.manager.delete_timer(name)
             self.refresh_timer_list()
 
@@ -71,6 +73,28 @@ class MainApp(tk.Tk):
             return
         timer = self.manager.timers[name]
         TimerRunner(self, timer)
+
+    def on_double_click(self, event):
+        item = self.timer_list.identify_row(event.y)
+        if item:
+            self.timer_list.selection_set(item)
+            self.edit_timer()
+
+    def on_click(self, event):
+        item = self.timer_list.identify_row(event.y)
+        col = self.timer_list.identify_column(event.x)
+        if not item or col == "#0":
+            return
+        self.timer_list.selection_set(item)
+        if col == "#1":
+            self.edit_timer()
+        elif col == "#2":
+            self.run_timer()
+        elif col == "#3":
+            self.delete_timer()
+
+    def on_delete_key(self, event):
+        self.delete_timer()
 
 
 if __name__ == "__main__":

--- a/time_entry.py
+++ b/time_entry.py
@@ -9,9 +9,10 @@ class TimeEntry(ttk.Entry):
         self.var = tk.StringVar()
         super().__init__(master, textvariable=self.var, **kwargs)
         self.set_seconds(seconds)
-        self.bind("<KeyRelease>", self._on_key)
+        self.bind("<FocusOut>", self._on_done)
+        self.bind("<Return>", self._on_done)
 
-    def _on_key(self, event):
+    def _on_done(self, event=None):
         digits = "".join(ch for ch in self.var.get() if ch.isdigit())
         if not digits:
             self.var.set("00:00:00")
@@ -25,15 +26,29 @@ class TimeEntry(ttk.Entry):
         hours = int(hour_digits) if hour_digits else 0
         self.var.set(f"{hours:02d}:{minutes:02d}:{sec:02d}")
         self.icursor(tk.END)
+        return "break" if event and event.keysym == "Return" else None
 
     def get_seconds(self) -> int:
-        try:
-            h, m, s = [int(x) for x in self.var.get().split(":")]
-        except ValueError:
-            return 0
-        m = min(m, 59)
-        s = min(s, 59)
-        return h * 3600 + m * 60 + s
+        text = self.var.get()
+        if ":" not in text:
+            digits = "".join(ch for ch in text if ch.isdigit())
+            if not digits:
+                return 0
+            sec = int(digits[-2:]) if len(digits) >= 2 else int(digits)
+            sec = min(sec, 59)
+            minute_digits = digits[-4:-2] if len(digits) > 2 else ""
+            minutes = int(minute_digits) if minute_digits else 0
+            minutes = min(minutes, 59)
+            hour_digits = digits[:-4] if len(digits) > 4 else ""
+            hours = int(hour_digits) if hour_digits else 0
+        else:
+            try:
+                hours, minutes, sec = [int(x) for x in text.split(":")]
+            except ValueError:
+                return 0
+            minutes = min(minutes, 59)
+            sec = min(sec, 59)
+        return hours * 3600 + minutes * 60 + sec
 
     def set_seconds(self, sec: int):
         h, rem = divmod(int(sec), 3600)


### PR DESCRIPTION
## Summary
- update time entry to validate on focus-out or Enter
- display timers in a treeview with inline edit, run and delete actions
- add Russian confirmation text for deletions

## Testing
- `python -m py_compile main.py activity_dialog.py models.py time_entry.py timer_editor.py timer_manager.py timer_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68614f953f1883239fae95e1cae47675