### PR TITLE
Add localization and sound settings

### DIFF
--- a/core/i18n.py
+++ b/core/i18n.py
@@ -1,0 +1,81 @@
+TRANSLATIONS = {
+    "en": {},
+    "ru": {
+        "Pomodoro Timer": "Таймер Помодоро",
+        "Open": "Настройки",
+        "Timers": "Таймеры",
+        "+ New Timer": "+ Новый таймер",
+        "Name": "Название",
+        "Description": "Описание",
+        "Sets": "Подходы",
+        "Rest between activities": "Отдых между активностями",
+        "Rest between sets": "Отдых между подходами",
+        "Activities": "Активности",
+        "Add activity": "Добавить активность",
+        "Save": "Сохранить",
+        "Cancel": "Отмена",
+        "Invalid name": "Неверное имя",
+        "Name must be 1-50 characters: letters, digits, spaces, '_' or '-'": "Имя должно быть 1-50 символов: буквы, цифры, пробелы, '_' или '-'",
+        "Invalid description": "Неверное описание",
+        "Description must be less than 200 characters": "Описание должно быть меньше 200 символов",
+        "Limit": "Лимит",
+        "Maximum 25 activities per timer": "Максимум 25 активностей на таймер",
+        "Unsaved changes": "Несохраненные изменения",
+        "у вас есть несохраненные изменения": "У вас есть несохраненные изменения",
+        "Delete": "Удалить",
+        "Timer": "Таймер",
+        "Timer: {name}": "Таймер: {name}",
+        "All sets completed": "Все подходы завершены",
+        "Rest": "Отдых",
+        "Rest between sets": "Отдых между подходами",
+        "Start": "Старт",
+        "Pause": "Пауза",
+        "Stop": "Стоп",
+        "Next": "Далее",
+        "Settings": "Настройки",
+        "Application language": "Язык приложения",
+        "Speech language": "Язык озвучки",
+        "Voice": "Голос",
+        "Notification sound": "Вид звуковых оповещений",
+        "None": "Нет",
+        "Beep": "Писк",
+        "Horn": "Гудок",
+        "VoiceTTS": "Озвучка",
+        "OK": "OK",
+        "timer started": "таймер запущен",
+        "timer stopped": "таймер остановлен",
+        "rest": "отдых",
+        "Timer name delete confirm": "Вы действительно хотите удалить таймер '{name}'?",
+        "Set {current}/{total}: {activity}": "Сет {current}/{total}: {activity}",
+        "Activity": "Активность",
+        "Duration": "Длительность",
+    },
+    "cn": {}
+}
+
+_current_lang = "en"
+_callbacks = []
+
+def set_language(lang: str):
+    global _current_lang
+    _current_lang = lang
+    for cb in list(_callbacks):
+        try:
+            cb()
+        except Exception:
+            pass
+
+def get_language():
+    return _current_lang
+
+
+def register(callback):
+    if callback not in _callbacks:
+        _callbacks.append(callback)
+
+def unregister(callback):
+    if callback in _callbacks:
+        _callbacks.remove(callback)
+
+def tr(text: str) -> str:
+    return TRANSLATIONS.get(_current_lang, {}).get(text, text)

--- a/core/settings.py
+++ b/core/settings.py
@@ -5,10 +5,11 @@ SETTINGS_FILE = "settings.json"
 
 
 class Settings:
-    def __init__(self, app_lang: str = "en", tts_lang: str = "en", voice: str | None = None):
+    def __init__(self, app_lang: str = "en", tts_lang: str = "en", voice: str | None = None, sound: str = "tts"):
         self.app_lang = app_lang
         self.tts_lang = tts_lang
         self.voice = voice
+        self.sound = sound
 
     @classmethod
     def load(cls, path: str = SETTINGS_FILE):
@@ -19,7 +20,8 @@ class Settings:
                 return cls(
                     data.get("app_lang", "en"),
                     data.get("tts_lang", "en"),
-                    data.get("voice")
+                    data.get("voice"),
+                    data.get("sound", "tts")
                 )
             except Exception:
                 pass
@@ -30,6 +32,7 @@ class Settings:
             "app_lang": self.app_lang,
             "tts_lang": self.tts_lang,
             "voice": self.voice,
+            "sound": self.sound,
         }
         try:
             with open(path, "w", encoding="utf-8") as f:

--- a/ui/activity_dialog.py
+++ b/ui/activity_dialog.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import ttk
 from ui.time_entry import TimeEntry
+from core.i18n import tr
 
 
 class ActivityDialog(tk.Toplevel):
@@ -8,22 +9,26 @@ class ActivityDialog(tk.Toplevel):
 
     def __init__(self, parent, activity=None):
         super().__init__(parent)
-        self.title("Activity")
+        self.title(tr("Activity"))
         self.resizable(False, False)
         self.result = None
 
-        ttk.Label(self, text="Name").grid(row=0, column=0, sticky="w")
+        self.lbl_name = ttk.Label(self, text=tr("Name"))
+        self.lbl_name.grid(row=0, column=0, sticky="w")
         self.entry_name = ttk.Entry(self)
         self.entry_name.grid(row=1, column=0, padx=5, sticky="we")
 
-        ttk.Label(self, text="Duration").grid(row=2, column=0, sticky="w")
+        self.lbl_duration = ttk.Label(self, text=tr("Duration"))
+        self.lbl_duration.grid(row=2, column=0, sticky="w")
         self.time_entry = TimeEntry(self)
         self.time_entry.grid(row=3, column=0, padx=5, sticky="we")
 
         btn = ttk.Frame(self)
         btn.grid(row=4, column=0, pady=5, sticky="e")
-        ttk.Button(btn, text="OK", command=self._ok).grid(row=0, column=0, padx=2)
-        ttk.Button(btn, text="Cancel", command=self.destroy).grid(row=0, column=1, padx=2)
+        self.btn_ok = ttk.Button(btn, text=tr("OK"), command=self._ok)
+        self.btn_ok.grid(row=0, column=0, padx=2)
+        self.btn_cancel = ttk.Button(btn, text=tr("Cancel"), command=self.destroy)
+        self.btn_cancel.grid(row=0, column=1, padx=2)
 
         if activity:
             # Pre-fill fields when editing an existing activity
@@ -31,6 +36,17 @@ class ActivityDialog(tk.Toplevel):
             self.time_entry.set_seconds(activity.duration)
 
         self.columnconfigure(0, weight=1)
+        self.update_idletasks()
+        x = parent.winfo_rootx() + (parent.winfo_width() - self.winfo_width()) // 2
+        y = parent.winfo_rooty() + (parent.winfo_height() - self.winfo_height()) // 2
+        self.geometry(f"+{x}+{y}")
+
+    def apply_i18n(self):
+        self.title(tr("Activity"))
+        self.lbl_name.config(text=tr("Name"))
+        self.lbl_duration.config(text=tr("Duration"))
+        self.btn_ok.config(text=tr("OK"))
+        self.btn_cancel.config(text=tr("Cancel"))
 
     def _ok(self):
         """Validate input and close the dialog with result."""

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -3,40 +3,61 @@ from tkinter import ttk
 
 from core.settings import Settings
 from core.tts import list_voices
+from core.i18n import tr, set_language
 
 
 class SettingsDialog(tk.Toplevel):
     def __init__(self, parent, settings: Settings):
         super().__init__(parent)
+        self.parent = parent
         self.settings = settings
-        self.title("Settings")
+        self.title(tr("Settings"))
         self.resizable(False, False)
 
-        ttk.Label(self, text="Application language").grid(row=0, column=0, sticky="w")
+        ttk.Label(self, text=tr("Application language")).grid(row=0, column=0, sticky="w")
         self.var_app = tk.StringVar(value=settings.app_lang)
         self.combo_app = ttk.Combobox(self, textvariable=self.var_app, values=["ru", "en", "cn"], state="readonly")
         self.combo_app.grid(row=1, column=0, padx=5, pady=2, sticky="we")
 
-        ttk.Label(self, text="Speech language").grid(row=2, column=0, sticky="w")
+        ttk.Label(self, text=tr("Speech language")).grid(row=2, column=0, sticky="w")
         self.var_tts_lang = tk.StringVar(value=settings.tts_lang)
         self.combo_tts = ttk.Combobox(self, textvariable=self.var_tts_lang, values=["ru", "en", "cn"], state="readonly")
         self.combo_tts.grid(row=3, column=0, padx=5, pady=2, sticky="we")
         self.combo_tts.bind("<<ComboboxSelected>>", self.update_voices)
 
-        ttk.Label(self, text="Voice").grid(row=4, column=0, sticky="w")
+        ttk.Label(self, text=tr("Notification sound")).grid(row=4, column=0, sticky="w")
+        self._sound_map = {
+            tr("None"): "none",
+            tr("Beep"): "beep",
+            tr("Horn"): "horn",
+            tr("VoiceTTS"): "tts",
+        }
+        inv = {v: k for k, v in self._sound_map.items()}
+        self.var_sound = tk.StringVar(value=inv.get(settings.sound, tr("None")))
+        self.combo_sound = ttk.Combobox(self, textvariable=self.var_sound,
+                                        values=list(self._sound_map.keys()), state="readonly")
+        self.combo_sound.grid(row=5, column=0, padx=5, pady=2, sticky="we")
+        self.combo_sound.bind("<<ComboboxSelected>>", self._sound_changed)
+
+        ttk.Label(self, text=tr("Voice")).grid(row=6, column=0, sticky="w")
         self.var_voice = tk.StringVar(value=settings.voice or "")
         self.combo_voice = ttk.Combobox(self, textvariable=self.var_voice, state="readonly")
-        self.combo_voice.grid(row=5, column=0, padx=5, pady=2, sticky="we")
+        self.combo_voice.grid(row=7, column=0, padx=5, pady=2, sticky="we")
 
         btn = ttk.Frame(self)
-        btn.grid(row=6, column=0, pady=5, sticky="e")
-        ttk.Button(btn, text="OK", command=self.on_ok).grid(row=0, column=0, padx=2)
-        ttk.Button(btn, text="Cancel", command=self.destroy).grid(row=0, column=1, padx=2)
+        btn.grid(row=8, column=0, pady=5, sticky="e")
+        ttk.Button(btn, text=tr("OK"), command=self.on_ok).grid(row=0, column=0, padx=2)
+        ttk.Button(btn, text=tr("Cancel"), command=self.destroy).grid(row=0, column=1, padx=2)
 
         self.columnconfigure(0, weight=1)
         self.update_voices()
+        self._sound_changed()
         self.grab_set()
         self.transient(parent)
+        self.update_idletasks()
+        x = parent.winfo_rootx() + (parent.winfo_width() - self.winfo_width()) // 2
+        y = parent.winfo_rooty() + (parent.winfo_height() - self.winfo_height()) // 2
+        self.geometry(f"+{x}+{y}")
 
     def update_voices(self, event=None):
         lang = self.var_tts_lang.get()
@@ -54,12 +75,21 @@ class SettingsDialog(tk.Toplevel):
             self.var_voice.set("")
             self.settings.voice = None
         self._voice_map = dict(zip(names, ids))
+        
+    def _sound_changed(self, event=None):
+        mode = self._sound_map.get(self.var_sound.get(), "none")
+        state = "readonly" if mode == "tts" else "disabled"
+        self.combo_voice.configure(state=state)
 
     def on_ok(self):
         self.settings.app_lang = self.var_app.get()
         self.settings.tts_lang = self.var_tts_lang.get()
+        self.settings.sound = self._sound_map.get(self.var_sound.get(), "none")
         selected = self.var_voice.get()
         if selected:
             self.settings.voice = self._voice_map.get(selected)
         self.settings.save()
+        set_language(self.settings.app_lang)
+        if hasattr(self.parent, "apply_i18n"):
+            self.parent.apply_i18n()
         self.destroy()

--- a/ui/timer_editor.py
+++ b/ui/timer_editor.py
@@ -3,6 +3,7 @@ from tkinter import ttk, messagebox
 import re
 from core.models import Activity, TimerConfig
 from ui.time_entry import TimeEntry
+from core.i18n import tr
 
 
 class TimerEditorFrame(ttk.Frame):
@@ -22,27 +23,33 @@ class TimerEditorFrame(ttk.Frame):
 
     def _build_widgets(self):
         """Construct the form for editing timer properties."""
-        ttk.Label(self, text="Name").grid(row=0, column=0, columnspan=2, sticky="w")
+        self.lbl_name = ttk.Label(self, text="Name")
+        self.lbl_name.grid(row=0, column=0, columnspan=2, sticky="w")
         self.entry_name = ttk.Entry(self, width=40)
         self.entry_name.grid(row=1, column=0, columnspan=2, sticky="we", pady=(0, 5))
 
-        ttk.Label(self, text="Description").grid(row=2, column=0, columnspan=2, sticky="w")
+        self.lbl_desc = ttk.Label(self, text="Description")
+        self.lbl_desc.grid(row=2, column=0, columnspan=2, sticky="w")
         self.text_desc = tk.Text(self, height=2, width=40, wrap="word")
         self.text_desc.grid(row=3, column=0, columnspan=2, sticky="we", pady=(0, 5))
 
-        ttk.Label(self, text="Sets").grid(row=4, column=0, columnspan=2, sticky="w")
+        self.lbl_sets = ttk.Label(self, text="Sets")
+        self.lbl_sets.grid(row=4, column=0, columnspan=2, sticky="w")
         self.spin_sets = ttk.Spinbox(self, from_=1, to=99, width=5)
         self.spin_sets.grid(row=5, column=0, columnspan=2, sticky="w", pady=(0, 5))
 
-        ttk.Label(self, text="Rest between activities").grid(row=6, column=0, columnspan=2, sticky="w")
+        self.lbl_rest_act = ttk.Label(self, text="Rest between activities")
+        self.lbl_rest_act.grid(row=6, column=0, columnspan=2, sticky="w")
         self.time_rest_act = TimeEntry(self, width=8)
         self.time_rest_act.grid(row=7, column=0, columnspan=2, sticky="w", pady=(0, 5))
 
-        ttk.Label(self, text="Rest between sets").grid(row=8, column=0, columnspan=2, sticky="w")
+        self.lbl_rest_set = ttk.Label(self, text="Rest between sets")
+        self.lbl_rest_set.grid(row=8, column=0, columnspan=2, sticky="w")
         self.time_rest_set = TimeEntry(self, width=8)
         self.time_rest_set.grid(row=9, column=0, columnspan=2, sticky="w", pady=(0, 5))
 
-        ttk.Label(self, text="Activities").grid(row=10, column=0, columnspan=2, sticky="w")
+        self.lbl_acts = ttk.Label(self, text="Activities")
+        self.lbl_acts.grid(row=10, column=0, columnspan=2, sticky="w")
         columns = ("time", "edit", "delete")
         self.tree = ttk.Treeview(self, columns=columns, show="tree", height=5)
         self.tree.grid(row=11, column=0, columnspan=2, sticky="nsew")
@@ -60,9 +67,22 @@ class TimerEditorFrame(ttk.Frame):
 
         btn_frame = ttk.Frame(self)
         btn_frame.grid(row=12, column=1, sticky="e", pady=5)
-        ttk.Button(btn_frame, text="Save", width=10, command=self.save).grid(row=0, column=0, padx=2)
-        ttk.Button(btn_frame, text="Cancel", width=10, command=self.cancel).grid(row=0, column=1, padx=2)
+        self.btn_save = ttk.Button(btn_frame, text="Save", width=10, command=self.save)
+        self.btn_save.grid(row=0, column=0, padx=2)
+        self.btn_cancel = ttk.Button(btn_frame, text="Cancel", width=10, command=self.cancel)
+        self.btn_cancel.grid(row=0, column=1, padx=2)
 
+    def apply_i18n(self):
+        from core.i18n import tr
+        self.lbl_name.config(text=tr("Name"))
+        self.lbl_desc.config(text=tr("Description"))
+        self.lbl_sets.config(text=tr("Sets"))
+        self.lbl_rest_act.config(text=tr("Rest between activities"))
+        self.lbl_rest_set.config(text=tr("Rest between sets"))
+        self.lbl_acts.config(text=tr("Activities"))
+        self.btn_save.config(text=tr("Save"))
+        self.btn_cancel.config(text=tr("Cancel"))
+        
     def edit_timer(self, timer=None):
         """Populate widgets with timer data and show the editor."""
         self.timer = timer or TimerConfig("New Timer")
@@ -109,7 +129,8 @@ class TimerEditorFrame(ttk.Frame):
         for i, act in enumerate(self.timer.activities):
             self.tree.insert("", "end", iid=str(i), text=act.name,
                             values=(self.format_time(act.duration), "✏", "🗑"))
-        self.tree.insert("", "end", iid="add", text="Add activity", values=("", "➕", ""))
+        from core.i18n import tr
+        self.tree.insert("", "end", iid="add", text=tr("Add activity"), values=("", "➕", ""))
         self.tree.config(height=min(len(self.timer.activities) + 1, 26))
 
     def format_time(self, sec):
@@ -121,7 +142,8 @@ class TimerEditorFrame(ttk.Frame):
     def add_activity(self):
         """Append a new default activity and start editing it."""
         if len(self.timer.activities) >= 25:
-            messagebox.showwarning("Limit", "Maximum 25 activities per timer")
+            from core.i18n import tr
+            messagebox.showwarning(tr("Limit"), tr("Maximum 25 activities per timer"))
             return
         new = Activity("New", 60)
         self.timer.activities.append(new)
@@ -201,8 +223,9 @@ class TimerEditorFrame(ttk.Frame):
         act = self.timer.activities[idx]
         changed = name != act.name or duration != act.duration
         if not save and changed:
+            from core.i18n import tr
             ans = messagebox.askyesnocancel(
-                "Unsaved changes", "у вас есть несохраненные изменения"
+                tr("Unsaved changes"), tr("у вас есть несохраненные изменения")
             )
             if ans is None:
                 return
@@ -221,16 +244,18 @@ class TimerEditorFrame(ttk.Frame):
         self.finish_edit(True)
         name = self.entry_name.get().strip()
         if not name or not re.fullmatch(r"[\w\- ]{1,50}", name):
+            from core.i18n import tr
             messagebox.showerror(
-                "Invalid name",
-                "Name must be 1-50 characters: letters, digits, spaces, '_' or '-'",
+                tr("Invalid name"),
+                tr("Name must be 1-50 characters: letters, digits, spaces, '_' or '-'"),
             )
             return
         desc = self.text_desc.get("1.0", "end").strip()
         if len(desc) > 200:
+            from core.i18n import tr
             messagebox.showerror(
-                "Invalid description",
-                "Description must be less than 200 characters",
+                tr("Invalid description"),
+                tr("Description must be less than 200 characters"),
             )
             return
         sets = int(self.spin_sets.get())


### PR DESCRIPTION
## Summary
- add translation helper module and translations
- extend `Settings` with `sound` option
- center settings and activity dialogs
- implement localized settings dialog with selectable sound type and voices
- update timer runner to use various notification sounds
- update main window and timer editor for dynamic i18n

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861793e63988323af84e12ef82e594c