### PR TITLE
Fix GUI editing and add deletion options

### DIFF
--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -22,3 +22,13 @@ def test_no_separators_outside_work_blocks():
     # dash should appear only between first two intervals of the first day
     assert lines[1] == '------------'
     assert lines[3] != '------------'  # no dash after the last interval of the day
+
+
+def test_no_empty_notes_at_edges():
+    tc = TimeCounter(LOG_PATH)
+    periods = tc.parse_periods()
+    for p in periods:
+        for d in p.get('dates', []):
+            if d['notes']:
+                assert d['notes'][0] != ''
+                assert d['notes'][-1] != ''

--- a/worktime/gui.py
+++ b/worktime/gui.py
@@ -88,6 +88,68 @@ class DateEntryDialog(simpledialog.Dialog):
         self.result = self.var.get()
 
 
+class PeriodDialog(simpledialog.Dialog):
+    """Dialog to specify start and end dates for a new period."""
+
+    def __init__(self, master: tk.Misc, existing: List[str]):
+        self.existing = existing
+        super().__init__(master, "New Period")
+
+    def body(self, master: tk.Frame) -> tk.Widget:
+        self.start_var = tk.StringVar()
+        self.end_var = tk.StringVar()
+        tk.Label(master, text="Start date:").grid(row=0, column=0, sticky="w", padx=5, pady=2)
+        self.start_entry = tk.Entry(master, textvariable=self.start_var)
+        self.start_entry.grid(row=0, column=1, padx=5, pady=2)
+        tk.Label(master, text="End date:").grid(row=1, column=0, sticky="w", padx=5, pady=2)
+        self.end_entry = tk.Entry(master, textvariable=self.end_var)
+        self.end_entry.grid(row=1, column=1, padx=5, pady=2)
+        for e in (self.start_entry, self.end_entry):
+            e.bind("<KeyRelease>", self._format)
+        return self.start_entry
+
+    def _format(self, event: tk.Event) -> None:
+        var = event.widget
+        if var not in (self.start_entry, self.end_entry):
+            return
+        v = var.get()
+        digits = "".join(ch for ch in v if ch.isdigit())[:8]
+        parts = []
+        if len(digits) >= 4:
+            parts.append(digits[:4])
+        if len(digits) >= 6:
+            parts.append(digits[4:6])
+        elif len(digits) > 4:
+            parts.append(digits[4:])
+        if len(digits) >= 8:
+            parts.append(digits[6:8])
+        var.delete(0, tk.END)
+        var.insert(0, ".".join(parts))
+
+    def validate(self) -> bool:
+        start = self.start_var.get()
+        end = self.end_var.get()
+        for val in (start, end):
+            if not DATE_PATTERN.match(val):
+                messagebox.showerror("Error", "Format YYYY.MM.DD")
+                return False
+            try:
+                datetime.strptime(val, "%Y.%m.%d")
+            except ValueError:
+                messagebox.showerror("Error", f"Invalid date {val}")
+                return False
+        if start not in self.existing or end not in self.existing:
+            messagebox.showerror("Error", "Date not found in log")
+            return False
+        if self.existing.index(start) > self.existing.index(end):
+            messagebox.showerror("Error", "Start date after end date")
+            return False
+        return True
+
+    def apply(self) -> None:
+        self.result = (self.start_var.get(), self.end_var.get())
+
+
 class DateEditDialog(simpledialog.Dialog):
     """Dialog to edit a date line and all its notes."""
 
@@ -246,7 +308,57 @@ class App(tk.Tk):
             return idx
         return -1
 
-    def refresh_list(self) -> None:
+    def _capture_state(self) -> dict:
+        state = {"open": set(), "focus": None}
+        def recurse(node: str):
+            if self.tree.item(node, "open"):
+                tag = self.tree.item(node, "tags")[0]
+                idx = self.tree.set(node, "idx")
+                state["open"].add((tag, idx))
+            for ch in self.tree.get_children(node):
+                recurse(ch)
+        for top in self.tree.get_children(""):
+            recurse(top)
+        focus = self.tree.focus()
+        if focus:
+            tag = self.tree.item(focus, "tags")[0]
+            idx = self.tree.set(focus, "idx")
+            state["focus"] = (tag, idx)
+        return state
+
+    def _restore_state(self, state: dict) -> None:
+        if not state:
+            return
+        def recurse(node: str):
+            tag = self.tree.item(node, "tags")[0]
+            idx = self.tree.set(node, "idx")
+            if (tag, idx) in state.get("open", set()):
+                self.tree.item(node, open=True)
+            for ch in self.tree.get_children(node):
+                recurse(ch)
+        for top in self.tree.get_children(""):
+            recurse(top)
+        focus = state.get("focus")
+        if focus:
+            for item in self.tree.get_children(""):
+                found = self._find_by_key(item, focus)
+                if found:
+                    self.tree.focus(found)
+                    break
+
+    def _find_by_key(self, node: str, key: tuple) -> Optional[str]:
+        tag = self.tree.item(node, "tags")[0]
+        idx = self.tree.set(node, "idx")
+        if (tag, idx) == key:
+            return node
+        for ch in self.tree.get_children(node):
+            res = self._find_by_key(ch, key)
+            if res:
+                return res
+        return None
+
+    def refresh_list(self, preserve: bool = False) -> None:
+        state = self._capture_state() if preserve else None
         self.tree.delete(*self.tree.get_children())
         if not self.tc:
             return
@@ -263,9 +375,16 @@ class App(tk.Tk):
                     line = self.tc.lines[line_idx]
                     display = line if line else "------------"
                     self.tree.insert(did, tk.END, text=display, tags=("note",), values=(line_idx, "⋮"))
+        if preserve:
+            self._restore_state(state)
 
     # ----------------------------------------------------- context menu
     def on_tree_click(self, event: tk.Event) -> None:
+        if self.edit_frame is not None:
+            x_root = self.tree.winfo_rootx() + event.x
+            y_root = self.tree.winfo_rooty() + event.y
+            if not self.edit_frame.winfo_containing(x_root, y_root):
+                self.finish_edit()
         item = self.tree.identify_row(event.y)
         col = self.tree.identify_column(event.x)
         if col == "#2" and item:
@@ -278,12 +397,16 @@ class App(tk.Tk):
         if "period" in tags:
             self.context_menu.add_command(label="Статус", command=lambda i=item: self.change_status(i))
             self.context_menu.add_command(label="+Период", command=self.add_period)
+            self.context_menu.add_command(label="Удалить", command=lambda i=item: self.delete_period(i))
         elif "date" in tags:
             self.context_menu.add_command(label="Ред.", command=lambda i=item: self.edit_date(i))
             self.context_menu.add_command(label="+Дата", command=lambda i=item: self.add_date(i))
+            self.context_menu.add_command(label="+Заметка", command=lambda i=item: self.add_note_to_date(i))
+            self.context_menu.add_command(label="Удалить", command=lambda i=item: self.delete_date(i))
         elif "note" in tags:
             self.context_menu.add_command(label="Ред.", command=lambda i=item: self.start_edit_note(i))
             self.context_menu.add_command(label="+", command=lambda i=item: self.add_note_after(i))
+            self.context_menu.add_command(label="Удалить", command=lambda i=item: self.delete_note(i))
         else:
             return
         self.context_menu.tk_popup(x, y)
@@ -349,14 +472,14 @@ class App(tk.Tk):
         self.tc.update_line(self.edit_index, line)
         self.edit_frame.destroy()
         self.edit_frame = None
-        self.refresh_list()
+        self.refresh_list(preserve=True)
 
     # ----------------------------------------------------- actions used by popup buttons
     def add_note_after(self, item: str) -> None:
         index = int(self.tree.set(item, "idx"))
         now = datetime.now().strftime("%H:%M")
         self.tc.insert_line_after(index, now)
-        self.refresh_list()
+        self.refresh_list(preserve=True)
         self.edit_note_by_index(index + 1)
 
     def edit_note_by_index(self, index: int) -> None:
@@ -385,7 +508,7 @@ class App(tk.Tk):
         )
         if dlg.result:
             self.tc.insert_date_after(index, dlg.result)
-            self.refresh_list()
+            self.refresh_list(preserve=True)
 
     def edit_date(self, item: str) -> None:
         index = int(self.tree.set(item, "idx"))
@@ -394,18 +517,66 @@ class App(tk.Tk):
             self.tc.update_line(index, dlg.result["date"])
             for off, line in enumerate(dlg.result["lines"]):
                 self.tc.update_line(index + 1 + off, line)
-            self.refresh_list()
+            self.refresh_list(preserve=True)
 
     def change_status(self, item: str) -> None:
         index = int(self.tree.set(item, "idx"))
         dlg = StatusDialog(self, "Status")
         if dlg.result:
             self.tc.change_status(index, dlg.result)
-            self.refresh_list()
+            self.refresh_list(preserve=True)
 
     def add_period(self) -> None:
-        if self.tc.mark_last_period_as_invoiced():
-            self.refresh_list()
+        if not self.tc:
+            return
+        existing = [l for l in self.tc.lines if DATE_PATTERN.match(l)]
+        dlg = PeriodDialog(self, existing)
+        if dlg.result:
+            start, end = dlg.result
+            self.tc.add_custom_period(start, end)
+            self.refresh_list(preserve=True)
+
+    def add_note_to_date(self, item: str) -> None:
+        index = int(self.tree.set(item, "idx"))
+        now = datetime.now().strftime("%H:%M")
+        self.tc.insert_line_after(index, now)
+        self.refresh_list(preserve=True)
+        self.edit_note_by_index(index + 1)
+
+    def delete_note(self, item: str) -> None:
+        index = int(self.tree.set(item, "idx"))
+        if messagebox.askokcancel("Delete", "Delete note?"):
+            self.tc.delete_lines(index, index)
+            self.refresh_list(preserve=True)
+
+    def delete_date(self, item: str) -> None:
+        index = int(self.tree.set(item, "idx"))
+        info = None
+        for p in self.tc.parse_periods():
+            for d in p.get("dates", []):
+                if d["start_idx"] == index:
+                    info = d
+                    break
+            if info:
+                break
+        if info and messagebox.askokcancel("Delete", "Delete date?"):
+            self.tc.delete_lines(info["start_idx"], info["end_idx"])
+            self.refresh_list(preserve=True)
+
+    def delete_period(self, item: str) -> None:
+        status_idx = int(self.tree.set(item, "idx"))
+        periods = self.tc.parse_periods()
+        target = None
+        for p in periods:
+            if self._status_index(p) == status_idx or (status_idx == -1 and p["start_idx"] == int(self.tree.set(item, "idx"))):
+                target = p
+                break
+        if target and messagebox.askokcancel("Delete", "Delete period?"):
+            end = self._status_index(target)
+            if end == -1:
+                end = target["end_idx"]
+            self.tc.delete_lines(target.get("start_idx", 0), end)
+            self.refresh_list(preserve=True)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- implement `PeriodDialog` with two smart date entries
- preserve tree expansion state across edits
- allow adding/removing notes, dates and periods
- support custom invoice period insertion
- add regression tests

## Testing
- `pytest -q`
- `python -m py_compile worktime/gui.py worktime/counter.py`

------
https://chatgpt.com/codex/tasks/task_e_6867c7c04cc88323868cc7540642eba8